### PR TITLE
Updated Prometheus query

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ evaluations.
 
 This setup expects Prometheus to be running in the cluster and configured to scrape pod resource metrics. The address
 for Prometheus can be passed through `-prometheus-url` flag.
+
+## Compatibility
+
+#### Tested on the following environment:
+
+- Kubernetes v1.17 with Docker v19.03
+- Prometheus v2.20
+- Kube-state-metrics v1.8

--- a/deploy/scaler-deployment.yaml
+++ b/deploy/scaler-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: system
       containers:
         - name: scaler
-          image: arjunrn/simple-scaler:ca121dd
+          image: denisjd/simple-scaler:v2.0
           args:
             - -prometheus-url=http://prometheus
           resources:

--- a/pkg/replicacalculator/prometheus.go
+++ b/pkg/replicacalculator/prometheus.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	prometheusQuery = `sum(rate(container_cpu_usage_seconds_total{pod_name=~"%s", namespace="%s"}[1m])) by(pod_name) / 
-		sum(kube_pod_container_resource_requests_cpu_cores{pod_name=~"%s", namespace="%s"}) by (pod_name)`
+	prometheusQuery = `sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",image!="",container!="POD",pod=~"%s",namespace="%s"}[1m])) by(pod) / 
+		sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics",pod=~"%s",namespace="%s"}) by (pod)`
 )
 
 type MetricsSource interface {
@@ -55,8 +55,9 @@ func (m *prometheusMetricsSource) GetPodMetrics(namespace string, podIDs []strin
 		return nil, fmt.Errorf("unexpected return type from the prometheus api call: %v", results.Type())
 	}
 	mapResults := make(map[string][]int)
+	log.Debugf("matrixResult ----: %v", matrixResult)
 	for _, r := range matrixResult {
-		podName := string(r.Metric["pod_name"])
+		podName := string(r.Metric["pod"])
 		mapResults[podName] = make([]int, len(r.Values))
 		for i, v := range r.Values {
 			mapResults[podName][i] = int(v.Value * 100)


### PR DESCRIPTION
Hi arjunrn,
Amazing project, really appreciates your work on this HPA.

I would like to make a few contributions to your project, beginning with the below changes:

## Compatibility Changes
- Updated Prometheus query to be compatible with a newer version of Kubernetes
- Tested on the following environment:
  * Kubernetes v1.17 with Docker v19.03
  * Prometheus v2.20
  * Kube-state-metrics v1.8

## Grafana Screenshot:
<img width="1281" alt="image" src="https://user-images.githubusercontent.com/78596481/107942268-ff1dc380-6fb0-11eb-9ffd-bc1e88083e9f.png">


## Prometheus config snippet:
```yaml
- job_name: kube-state-metrics
  honor_timestamps: true
  scrape_interval: 15s
  scrape_timeout: 10s
  metrics_path: /metrics
  scheme: http
  static_configs:
  - targets:
    - kube-state-metrics.kube-system.svc.cluster.local:8080

- job_name: kubernetes-cadvisor
  honor_timestamps: true
  scrape_interval: 15s
  scrape_timeout: 10s
  metrics_path: /metrics
  scheme: https
  kubernetes_sd_configs:
  - role: node
  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  tls_config:
    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    insecure_skip_verify: false
  relabel_configs:
  - separator: ;
    regex: __meta_kubernetes_node_label_(.+)
    replacement: $1
    action: labelmap
  - separator: ;
    regex: (.*)
    target_label: __address__
    replacement: kubernetes.default.svc:443
    action: replace
  - source_labels: [__meta_kubernetes_node_name]
    separator: ;
    regex: (.+)
    target_label: __metrics_path__
    replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
    action: replace
```